### PR TITLE
Reverting dev dependency to correct section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     },
     "require": {
         "php": "^7.1",
-        "http-interop/http-factory-tests": "^0.5.0",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
+        "http-interop/http-factory-tests": "^0.5.0",
         "overtrue/phplint": "^1.0",
         "phpunit/phpunit": "^6.5",
         "squizlabs/php_codesniffer": "^3.0"


### PR DESCRIPTION
Introduced in: https://github.com/tuupola/http-factory/commit/e6b5ee2a683577d9b3f2c9c821e6fece2e8df191

PHPUnit and a lot of other dev dependencies bubble into dependencies because of this.

When I revert to previous version:

  - Removing webmozart/assert (1.3.0)
  - Removing theseer/tokenizer (1.1.0)
  - Removing sebastian/version (2.0.1)
  - Removing sebastian/resource-operations (1.0.0)
  - Removing sebastian/recursion-context (3.0.0)
  - Removing sebastian/object-reflector (1.1.1)
  - Removing sebastian/object-enumerator (3.0.3)
  - Removing sebastian/global-state (2.0.0)
  - Removing sebastian/exporter (3.1.0)
  - Removing sebastian/environment (3.1.0)
  - Removing sebastian/diff (3.0.1)
  - Removing sebastian/comparator (3.0.2)
  - Removing sebastian/code-unit-reverse-lookup (1.0.1)
  - Removing psr/http-factory (1.0.0)
  - Removing phpunit/phpunit (7.3.1)
  - Removing phpunit/php-token-stream (3.0.0)
  - Removing phpunit/php-timer (2.0.0)
  - Removing phpunit/php-text-template (1.2.1)
  - Removing phpunit/php-file-iterator (2.0.1)
  - Removing phpunit/php-code-coverage (6.0.7)
  - Removing phpspec/prophecy (1.8.0)
  - Removing phpdocumentor/type-resolver (0.4.0)
  - Removing phpdocumentor/reflection-docblock (4.3.0)
  - Removing phpdocumentor/reflection-common (1.0.1)
  - Removing phar-io/version (2.0.1)
  - Removing phar-io/manifest (1.0.3)
  - Removing myclabs/deep-copy (1.8.1)
  - Removing http-interop/http-factory-tests (0.5.0)
  - Downgrading tuupola/callable-handler (0.4.0 => 0.3.0): Downloading (100%)
  - Installing http-interop/http-factory (0.3.0): Downloading (100%)
  - Downgrading tuupola/http-factory (0.4.0 => 0.3.0): Downloading (100%)
  - Downgrading tuupola/slim-jwt-auth (3.1.0 => 3.0.0): Downloading (100%)