### PR TITLE
Support for Slim-Psr7 implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - PSR7_LIBRARY="zendframework/zend-diactoros:^1.0"
     - PSR7_LIBRARY="zendframework/zend-diactoros:^2.0"
     - PSR7_LIBRARY="nyholm/psr7"
+    - PSR7_LIBRARY="slim/psr7"
     - PSR7_LIBRARY="slim/slim:^3.0"
     - PSR7_LIBRARY="guzzlehttp/psr7"
 

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -38,6 +38,7 @@ use Nyholm\Psr7\Request as NyholmRequest;
 use Slim\Http\Request as SlimRequest;
 use Slim\Http\Uri as SlimUri;
 use Slim\Http\Headers as SlimHeaders;
+use Slim\Psr7\Factory\RequestFactory as SlimPsr7RequestFactory;
 use Zend\Diactoros\Request as DiactorosRequest;
 
 use Psr\Http\Message\RequestInterface;
@@ -56,6 +57,10 @@ final class RequestFactory implements RequestFactoryInterface
 
         if (class_exists(NyholmRequest::class)) {
             return new NyholmRequest($method, $uri);
+        }
+
+        if (class_exists(SlimPsr7RequestFactory::class)) {
+            return (new SlimPsr7RequestFactory)->createRequest($method, $uri);
         }
 
         if (class_exists(SlimRequest::class)) {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -36,6 +36,7 @@ namespace Tuupola\Http\Factory;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Nyholm\Psr7\Response as NyholmResponse;
 use Slim\Http\Response as SlimResponse;
+use Slim\Psr7\Factory\ResponseFactory as SlimPsr7ResponseFactory;
 use Zend\Diactoros\Response as DiactorosResponse;
 
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -54,6 +55,10 @@ final class ResponseFactory implements ResponseFactoryInterface
 
         if (class_exists(NyholmResponse::class)) {
             return new NyholmResponse($code, [], null, "1.1", $reason);
+        }
+
+        if (class_exists(SlimPsr7ResponseFactory::class)) {
+            return (new SlimPsr7ResponseFactory)->createResponse($code, $reason);
         }
 
         if (class_exists(SlimResponse::class)) {

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -38,9 +38,8 @@ use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
 use Slim\Http\Request as SlimServerRequest;
 use Slim\Http\Uri as SlimUri;
 use Slim\Http\Headers as SlimHeaders;
-use Slim\Http\Environment as SlimEnvironment;
+use Slim\Psr7\Factory\ServerRequestFactory as SlimPsr7ServerRequestFactory;
 use Zend\Diactoros\ServerRequest as DiactorosServerRequest;
-use Zend\Diactoros\ServerRequestFactory as DiactorosServerRequestFactory;
 
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -58,6 +57,10 @@ final class ServerRequestFactory implements ServerRequestFactoryInterface
 
         if (class_exists(NyholmServerRequest::class)) {
             return new NyholmServerRequest($method, $uri, [], null, "1.1", $serverParams);
+        }
+
+        if (class_exists(SlimPsr7ServerRequestFactory::class)) {
+            return (new SlimPsr7ServerRequestFactory)->createServerRequest($method, $uri, $serverParams);
         }
 
         if (class_exists(SlimServerRequest::class)) {

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -36,6 +36,7 @@ namespace Tuupola\Http\Factory;
 use GuzzleHttp\Psr7\Stream as GuzzleStream;
 use Nyholm\Psr7\Stream as NyholmStream;
 use Slim\Http\Stream as SlimStream;
+use Slim\Psr7\Factory\StreamFactory as SlimPsr7StreamFactory;
 use Zend\Diactoros\Stream as DiactorosStream;
 
 use Psr\Http\Message\StreamFactoryInterface;
@@ -48,6 +49,10 @@ class StreamFactory implements StreamFactoryInterface
      */
     public function createStream(string $content = ""): StreamInterface
     {
+        if (class_exists(SlimPsr7StreamFactory::class)) {
+            return (new SlimPsr7StreamFactory)->createStream($content);
+        }
+
         $resource = fopen("php://temp", "r+");
         $stream = $this->createStreamFromResource($resource);
         $stream->write($content);
@@ -60,6 +65,10 @@ class StreamFactory implements StreamFactoryInterface
      */
     public function createStreamFromFile(string $filename, string $mode = "r"): StreamInterface
     {
+        if (class_exists(SlimPsr7StreamFactory::class)) {
+            return (new SlimPsr7StreamFactory)->createStreamFromFile($filename, $mode);
+        }
+
         $resource = fopen($filename, $mode);
         return $this->createStreamFromResource($resource);
     }
@@ -75,6 +84,10 @@ class StreamFactory implements StreamFactoryInterface
 
         if (class_exists(NyholmStream::class)) {
             return NyholmStream::create($resource);
+        }
+
+        if (class_exists(SlimPsr7StreamFactory::class)) {
+            return (new SlimPsr7StreamFactory)->createStreamFromResource($resource);
         }
 
         if (class_exists(SlimStream::class)) {

--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -36,6 +36,7 @@ namespace Tuupola\Http\Factory;
 use GuzzleHttp\Psr7\UploadedFile as GuzzleUploadedFile;
 use Nyholm\Psr7\UploadedFile as NyholmUploadedFile;
 use Slim\Http\UploadedFile as SlimUploadedFile;
+use Slim\Psr7\Factory\UploadedFileFactory as SlimPsr7UploadedFileFactory;
 use Zend\Diactoros\UploadedFile as DiactorosUploadedFile;
 
 use Psr\Http\Message\UploadedFileFactoryInterface;
@@ -70,6 +71,16 @@ final class UploadedFileFactory implements UploadedFileFactoryInterface
 
         if (class_exists(NyholmUploadedFile::class)) {
             return new NyholmUploadedFile(
+                $stream,
+                $size,
+                $error,
+                $clientFilename,
+                $clientMediaType
+            );
+        }
+
+        if (class_exists(SlimPsr7UploadedFileFactory::class)) {
+            return (new SlimPsr7UploadedFileFactory)->createUploadedFile(
                 $stream,
                 $size,
                 $error,

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -36,6 +36,7 @@ namespace Tuupola\Http\Factory;
 use GuzzleHttp\Psr7\Uri as GuzzleUri;
 use Nyholm\Psr7\Uri as NyholmUri;
 use Slim\Http\Uri as SlimUri;
+use Slim\Psr7\Factory\UriFactory as SlimPsr7UriFactory;
 use Zend\Diactoros\Uri as DiactorosUri;
 
 use Psr\Http\Message\UriFactoryInterface;
@@ -54,6 +55,10 @@ final class UriFactory implements UriFactoryInterface
 
         if (class_exists(NyholmUri::class)) {
             return new NyholmUri($uri);
+        }
+
+        if (class_exists(SlimPsr7UriFactory::class)) {
+            return (new SlimPsr7UriFactory)->createUri($uri);
         }
 
         if (class_exists(SlimUri::class)) {


### PR DESCRIPTION
## The issue
In Slim v4 the authors separated the PST-7 implementation to a separate base package (`slim/psr7`) and created a package that "decorates" the base one for use with Slim v4 called `slim/http`.
Unfortunately, the class name `Slim\Http\Response` collides with the implementation in Slim v3 and thus cause failure during the detection used in this package, when used with Slim v4 (at least 4.0.0-beta).

## The solution
This PR adds support for the new `slim/psr7` package.

---

closes #9 