### PR TITLE
Move Zend Diactoros detection before Slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+
+## [1.4.0](https://github.com/tuupola/http-factory/compare/1.3.0...1.4.0) - unreleased
+### Changed
+- Zend Diactoros is now detected before Slim. This is to avoid class not found errors in  projects using Slim 2 and legacy Diactoros. ([#21](https://github.com/tuupola/http-factory/pull/21)).
+
 ## [1.3.0](https://github.com/tuupola/http-factory/compare/1.2.0...1.3.0) - 2020-10-01
 ### Added
 - Support for `laminas/laminas-diactoros` ([#17](https://github.com/tuupola/http-factory/pull/17)).

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -64,6 +64,10 @@ final class RequestFactory implements RequestFactoryInterface
             return (new SlimPsr7RequestFactory)->createRequest($method, $uri);
         }
 
+        if (class_exists(ZendDiactorosRequest::class)) {
+            return new ZendDiactorosRequest($uri, $method);
+        }
+
         if (class_exists(SlimRequest::class)) {
             $uri = SlimUri::createFromString($uri);
             $headers = new SlimHeaders;
@@ -73,10 +77,6 @@ final class RequestFactory implements RequestFactoryInterface
 
         if (class_exists(GuzzleRequest::class)) {
             return new GuzzleRequest($method, $uri);
-        }
-
-        if (class_exists(ZendDiactorosRequest::class)) {
-            return new ZendDiactorosRequest($uri, $method);
         }
 
         throw new \RuntimeException("No PSR-7 implementation available");

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -62,16 +62,16 @@ final class ResponseFactory implements ResponseFactoryInterface
             return (new SlimPsr7ResponseFactory)->createResponse($code, $reason);
         }
 
+        if (class_exists(ZendDiactorosResponse::class)) {
+            return (new ZendDiactorosResponse)->withStatus($code, $reason);
+        }
+
         if (class_exists(SlimResponse::class)) {
             return (new SlimResponse)->withStatus($code, $reason);
         }
 
         if (class_exists(GuzzleResponse::class)) {
             return new GuzzleResponse($code, [], null, "1.1", $reason);
-        }
-
-        if (class_exists(ZendDiactorosResponse::class)) {
-            return (new ZendDiactorosResponse)->withStatus($code, $reason);
         }
 
         throw new \RuntimeException("No PSR-7 implementation available");

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -64,6 +64,10 @@ final class ServerRequestFactory implements ServerRequestFactoryInterface
             return (new SlimPsr7ServerRequestFactory)->createServerRequest($method, $uri, $serverParams);
         }
 
+        if (class_exists(ZendDiactorosServerRequest::class)) {
+            return new ZendDiactorosServerRequest($serverParams, [], $uri, $method);
+        }
+
         if (class_exists(SlimServerRequest::class)) {
             $uri = SlimUri::createFromString($uri);
             $headers = new SlimHeaders;
@@ -73,10 +77,6 @@ final class ServerRequestFactory implements ServerRequestFactoryInterface
 
         if (class_exists(GuzzleServerRequest::class)) {
             return new GuzzleServerRequest($method, $uri, [], null, "1.1", $serverParams);
-        }
-
-        if (class_exists(ZendDiactorosServerRequest::class)) {
-            return new ZendDiactorosServerRequest($serverParams, [], $uri, $method);
         }
 
         throw new \RuntimeException("No PSR-7 implementation available");

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -110,16 +110,16 @@ class StreamFactory implements StreamFactoryInterface
             return (new SlimPsr7StreamFactory)->createStreamFromResource($resource);
         }
 
+        if (class_exists(ZendDiactorosStream::class)) {
+            return new ZendDiactorosStream($resource);
+        }
+
         if (class_exists(SlimStream::class)) {
             return new SlimStream($resource);
         }
 
         if (class_exists(GuzzleStream::class)) {
             return new GuzzleStream($resource);
-        }
-
-        if (class_exists(ZendDiactorosStream::class)) {
-            return new ZendDiactorosStream($resource);
         }
 
         throw new RuntimeException("No PSR-7 implementation available");

--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -90,6 +90,16 @@ final class UploadedFileFactory implements UploadedFileFactoryInterface
             );
         }
 
+        if (class_exists(ZendDiactorosUploadedFile::class)) {
+            return new ZendDiactorosUploadedFile(
+                $stream,
+                $size,
+                $error,
+                $clientFilename,
+                $clientMediaType
+            );
+        }
+
         if (class_exists(SlimUploadedFile::class)) {
             $meta = $stream->getMetadata();
             $file = $meta["uri"];
@@ -110,16 +120,6 @@ final class UploadedFileFactory implements UploadedFileFactoryInterface
 
         if (class_exists(GuzzleUploadedFile::class)) {
             return new GuzzleUploadedFile(
-                $stream,
-                $size,
-                $error,
-                $clientFilename,
-                $clientMediaType
-            );
-        }
-
-        if (class_exists(ZendDiactorosUploadedFile::class)) {
-            return new ZendDiactorosUploadedFile(
                 $stream,
                 $size,
                 $error,

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -62,6 +62,10 @@ final class UriFactory implements UriFactoryInterface
             return (new SlimPsr7UriFactory)->createUri($uri);
         }
 
+        if (class_exists(ZendDiactorosUri::class)) {
+            return new ZendDiactorosUri($uri);
+        }
+
         if (class_exists(SlimUri::class)) {
             if (false === parse_url($uri)) {
                 throw new \InvalidArgumentException("Invalid URI: $uri");
@@ -71,10 +75,6 @@ final class UriFactory implements UriFactoryInterface
 
         if (class_exists(GuzzleUri::class)) {
             return new GuzzleUri($uri);
-        }
-
-        if (class_exists(ZendDiactorosUri::class)) {
-            return new ZendDiactorosUri($uri);
         }
 
         throw new \RuntimeException("No PSR-7 implementation available");


### PR DESCRIPTION
This is to avoid "Class Slim\Http\Uri not found" errors in legacy
projects using Slim 2 and Zend Diactoros.